### PR TITLE
Add a convenience cloud starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,38 @@
 [![Build Status][ci-img]][ci] [![Released Version][maven-img]][maven]
 
+## Dependencies
+
+The `opentracing-spring-zipkin-starter` simply contains the code needed to provide a Zipkin implementation of the OpenTracing's `io.opentracing.Tracer`
+interface.
+
+For a project to be able to actually instrument a Spring stack, one or more of the purpose built starters (like `io.opentracing.contrib:opentracing-spring-web-starter` or `io.opentracing.contrib:opentracing-spring-cloud-starter`)  
+would also have to be included in the POM.
+
+The `opentracing-spring-zipkin-web-starter` starter is convenience starter that includes both `opentracing-spring-zipkin-starter` and `opentracing-spring-web-starter`
+This means that by including it, simple web Spring Boot microservices include all the necessary dependencies to instrument Web requests / responses and send traces to Zipkin.
+
+The `opentracing-spring-zipkin-cloud-starter` starter is convenience starter that includes both `opentracing-spring-zipkin-starter` and `opentracing-spring-cloud-starter`
+This means that by including it, all parts of the Spring Cloud stack supported by Opentracing will be instrumented
+
 ## Configuration
 
 ```xml
 <dependency>
   <groupId>io.opentracing.contrib</groupId>
-  <artifactId>opentracing-spring-zipkin-starter</artifactId>
+  <artifactId>opentracing-spring-zipkin-web-starter</artifactId>
 </dependency>
 ```
 
-The dependency will ensure that Spring Boot will auto configure a Zipkin implementation of OpenTracing's `Tracer` when the application starts.
+or
+
+```xml
+<dependency>
+  <groupId>io.opentracing.contrib</groupId>
+  <artifactId>opentracing-spring-zipkin-cloud-starter</artifactId>
+</dependency>
+``` 
+
+Either dependency will ensure that Spring Boot will auto configure a Zipkin implementation of OpenTracing's `Tracer` when the application starts.
 
 By default, the Zipkin server is expected to collect traces at `http://localhost:9411/api/v2/spans`
 encoded with `JSON_V2`. 

--- a/opentracing-spring-zipkin-cloud-starter/pom.xml
+++ b/opentracing-spring-zipkin-cloud-starter/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2018 The OpenTracing Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.opentracing.contrib</groupId>
+        <artifactId>opentracing-spring-zipkin-parent</artifactId>
+        <version>0.1.4-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>opentracing-spring-zipkin-cloud-starter</artifactId>
+
+    <properties>
+        <main.basedir>${project.basedir}/..</main.basedir>
+        <opentracing-spring-cloud-starter.version>0.1.15</opentracing-spring-cloud-starter.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>opentracing-spring-zipkin-starter</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>opentracing-spring-cloud-starter</artifactId>
+            <version>${opentracing-spring-cloud-starter.version}</version>
+        </dependency>
+    </dependencies>
+
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
   <version>0.1.4-SNAPSHOT</version>
   <modules>
     <module>opentracing-spring-zipkin-starter</module>
+    <module>opentracing-spring-zipkin-cloud-starter</module>
     <module>opentracing-spring-zipkin-web-starter</module>
     <module>opentracing-spring-zipkin-web-starter-it</module>
   </modules>


### PR DESCRIPTION
The starter includes both the zipkin Tracer auto-configuration code
as well as OpenTracing's Spring web auto-configuration