### PR TITLE
Update brave and zipkin version

### DIFF
--- a/opentracing-spring-zipkin-starter/pom.xml
+++ b/opentracing-spring-zipkin-starter/pom.xml
@@ -88,7 +88,7 @@
         <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>io.zipkin.java</groupId>
+        <groupId>io.zipkin.zipkin2</groupId>
         <artifactId>zipkin-junit</artifactId>
         <scope>test</scope>
         <version>${version.zipkin}</version>

--- a/opentracing-spring-zipkin-starter/src/test/java/io/opentracing/contrib/java/spring/zipkin/starter/AbstractZipkinTracerSenderSpringTest.java
+++ b/opentracing-spring-zipkin-starter/src/test/java/io/opentracing/contrib/java/spring/zipkin/starter/AbstractZipkinTracerSenderSpringTest.java
@@ -21,7 +21,8 @@ public abstract class AbstractZipkinTracerSenderSpringTest extends AbstractZipki
   protected void assertSenderUrl(String expected) {
     assertThat(getTracer())
         .extracting("brave4")
-        .extracting("reporter")
+        .extracting("spanReporter")
+        .extracting("delegate")
         .extracting("sender")
         .extracting("endpoint")
         .extracting("url")

--- a/opentracing-spring-zipkin-starter/src/test/java/io/opentracing/contrib/java/spring/zipkin/starter/AbstractZipkinTracerServiceNameTest.java
+++ b/opentracing-spring-zipkin-starter/src/test/java/io/opentracing/contrib/java/spring/zipkin/starter/AbstractZipkinTracerServiceNameTest.java
@@ -20,8 +20,7 @@ public abstract class AbstractZipkinTracerServiceNameTest extends AbstractZipkin
   protected void assertServiceName(String expected) {
     assertThat(getTracer())
         .extracting("brave4")
-        .extracting("recorder")
-        .extracting("spanMap")
+        .extracting("pendingSpanRecords")
         .extracting("endpoint")
         .extracting("serviceName")
         .containsOnly(expected);

--- a/opentracing-spring-zipkin-starter/src/test/java/io/opentracing/contrib/java/spring/zipkin/starter/sender/ZipkinSenderJsonV1Test.java
+++ b/opentracing-spring-zipkin-starter/src/test/java/io/opentracing/contrib/java/spring/zipkin/starter/sender/ZipkinSenderJsonV1Test.java
@@ -23,8 +23,8 @@ import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.Test;
 import org.springframework.test.context.TestPropertySource;
-import zipkin.Span;
-import zipkin.junit.ZipkinRule;
+import zipkin2.Span;
+import zipkin2.junit.ZipkinRule;
 
 /**
  * @author Pavol Loffay
@@ -63,7 +63,7 @@ public class ZipkinSenderJsonV1Test extends AbstractZipkinTracerSenderSpringTest
     });
     List<Span> trace = zipkin.getTraces().get(0);
     assertEquals(1, trace.size());
-    assertEquals("bar", trace.get(0).name);
+    assertEquals("bar", trace.get(0).name());
     zipkin.shutdown();
   }
 }

--- a/opentracing-spring-zipkin-starter/src/test/java/io/opentracing/contrib/java/spring/zipkin/starter/sender/ZipkinTracerWithDefaultSenderSpringTest.java
+++ b/opentracing-spring-zipkin-starter/src/test/java/io/opentracing/contrib/java/spring/zipkin/starter/sender/ZipkinTracerWithDefaultSenderSpringTest.java
@@ -21,8 +21,8 @@ import io.opentracing.contrib.java.spring.zipkin.starter.AbstractZipkinTracerSen
 import java.io.IOException;
 import java.util.List;
 import org.junit.Test;
-import zipkin.Span;
-import zipkin.junit.ZipkinRule;
+import zipkin2.Span;
+import zipkin2.junit.ZipkinRule;
 
 public class ZipkinTracerWithDefaultSenderSpringTest extends AbstractZipkinTracerSenderSpringTest {
 
@@ -42,7 +42,7 @@ public class ZipkinTracerWithDefaultSenderSpringTest extends AbstractZipkinTrace
     });
     List<Span> trace = zipkin.getTraces().get(0);
     assertEquals(1, trace.size());
-    assertEquals("bar", trace.get(0).name);
+    assertEquals("bar", trace.get(0).name());
     zipkin.shutdown();
   }
 

--- a/opentracing-spring-zipkin-web-starter-it/pom.xml
+++ b/opentracing-spring-zipkin-web-starter-it/pom.xml
@@ -80,7 +80,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.zipkin.java</groupId>
+      <groupId>io.zipkin.zipkin2</groupId>
       <artifactId>zipkin-junit</artifactId>
       <scope>test</scope>
       <version>${version.zipkin}</version>

--- a/opentracing-spring-zipkin-web-starter-it/src/test/java/io/opentracing/contrib/java/spring/zipkin/starter/it/ZipkinIntegrationTest.java
+++ b/opentracing-spring-zipkin-web-starter-it/src/test/java/io/opentracing/contrib/java/spring/zipkin/starter/it/ZipkinIntegrationTest.java
@@ -33,8 +33,8 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
-import zipkin.Span;
-import zipkin.junit.ZipkinRule;
+import zipkin2.Span;
+import zipkin2.junit.ZipkinRule;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(
@@ -61,7 +61,7 @@ public class ZipkinIntegrationTest {
     await().atMost(10, TimeUnit.SECONDS).until(() -> zipkin.getTraces().size() == 1);
     final List<List<Span>> traces = zipkin.getTraces();
     final List<Span> spans = traces.get(0);
-    assertThat(spans.get(0).serviceNames()).containsExactly(SERVICE_NAME);
+    assertThat(spans.get(0).localServiceName()).isEqualTo(SERVICE_NAME);
   }
 
   //create the opentracing.zipkin properties from the information of the running container

--- a/pom.xml
+++ b/pom.xml
@@ -66,9 +66,9 @@
     <version.io.opentracing>0.31.0</version.io.opentracing>
     <version.io.opentracing.contrib-opentracing-spring-tracer>0.1.0</version.io.opentracing.contrib-opentracing-spring-tracer>
     <version.org.springframework.boot>1.5.12.RELEASE</version.org.springframework.boot>
-    <version.brave-opentracing>0.30.3</version.brave-opentracing>
+    <version.brave-opentracing>0.31.3</version.brave-opentracing>
     <version.zipkin-sender-okhttp>2.6.0</version.zipkin-sender-okhttp>
-    <version.zipkin>2.8.1</version.zipkin>
+    <version.zipkin>2.10.4</version.zipkin>
     <version.org.awaitility-awaitility>3.0.0</version.org.awaitility-awaitility>
     <version.test-containers>1.7.3</version.test-containers>
 


### PR DESCRIPTION
Because io.opentracing.brave:brave-opentracing:0.30.3 contains a dependency to brave-tests, it should be upgraded to the most recent version, which [fixes](https://github.com/openzipkin-contrib/brave-opentracing/commit/8a71ad2216923c350e2f536fbd5992b8226480bd) the dependency scope. 

This also updates brave to version 5.x. Because of some API changes I had to update zipkin to a newer version, too.