### PR TITLE
update dependencies

### DIFF
--- a/.settings.xml
+++ b/.settings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2018 The OpenTracing Authors
+    Copyright 2018-2019 The OpenTracing Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/opentracing-spring-zipkin-cloud-starter/pom.xml
+++ b/opentracing-spring-zipkin-cloud-starter/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2018 The OpenTracing Authors
+    Copyright 2018-2019 The OpenTracing Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/opentracing-spring-zipkin-cloud-starter/pom.xml
+++ b/opentracing-spring-zipkin-cloud-starter/pom.xml
@@ -27,7 +27,7 @@
 
     <properties>
         <main.basedir>${project.basedir}/..</main.basedir>
-        <opentracing-spring-cloud-starter.version>0.1.15</opentracing-spring-cloud-starter.version>
+        <opentracing-spring-cloud-starter.version>0.3.2</opentracing-spring-cloud-starter.version>
     </properties>
 
     <dependencies>

--- a/opentracing-spring-zipkin-starter/pom.xml
+++ b/opentracing-spring-zipkin-starter/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2018 The OpenTracing Authors
+    Copyright 2018-2019 The OpenTracing Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/opentracing-spring-zipkin-starter/src/test/java/io/opentracing/contrib/java/spring/zipkin/starter/AbstractZipkinTracerSenderSpringTest.java
+++ b/opentracing-spring-zipkin-starter/src/test/java/io/opentracing/contrib/java/spring/zipkin/starter/AbstractZipkinTracerSenderSpringTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 The OpenTracing Authors
+ * Copyright 2018-2019 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -11,7 +11,6 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package io.opentracing.contrib.java.spring.zipkin.starter;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -20,12 +19,13 @@ public abstract class AbstractZipkinTracerSenderSpringTest extends AbstractZipki
 
   protected void assertSenderUrl(String expected) {
     assertThat(getTracer())
-        .extracting("brave4")
-        .extracting("spanReporter")
-        .extracting("delegate")
-        .extracting("sender")
-        .extracting("endpoint")
-        .extracting("url")
-        .containsOnly(expected);
+            .extracting("delegate")
+            .extracting("finishedSpanHandler")
+            .extracting("delegate")
+            .extracting("spanReporter")
+            .extracting("sender")
+            .extracting("endpoint")
+            .extracting("url")
+            .containsOnly(expected);
   }
 }

--- a/opentracing-spring-zipkin-starter/src/test/java/io/opentracing/contrib/java/spring/zipkin/starter/AbstractZipkinTracerServiceNameTest.java
+++ b/opentracing-spring-zipkin-starter/src/test/java/io/opentracing/contrib/java/spring/zipkin/starter/AbstractZipkinTracerServiceNameTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 The OpenTracing Authors
+ * Copyright 2018-2019 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -19,11 +19,12 @@ public abstract class AbstractZipkinTracerServiceNameTest extends AbstractZipkin
 
   protected void assertServiceName(String expected) {
     assertThat(getTracer())
-        .extracting("brave4")
-        .extracting("pendingSpanRecords")
-        .extracting("endpoint")
-        .extracting("serviceName")
-        .containsOnly(expected);
+            .extracting("delegate")
+            .extracting("finishedSpanHandler")
+            .extracting("delegate")
+            .extracting("converter")
+            .extracting("localServiceName")
+            .containsOnly(expected);
   }
 
 }

--- a/opentracing-spring-zipkin-web-starter-it/pom.xml
+++ b/opentracing-spring-zipkin-web-starter-it/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2018 The OpenTracing Authors
+    Copyright 2018-2019 The OpenTracing Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/opentracing-spring-zipkin-web-starter-it/src/test/java/io/opentracing/contrib/java/spring/zipkin/starter/it/ZipkinIntegrationTest.java
+++ b/opentracing-spring-zipkin-web-starter-it/src/test/java/io/opentracing/contrib/java/spring/zipkin/starter/it/ZipkinIntegrationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 The OpenTracing Authors
+ * Copyright 2018-2019 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -25,7 +25,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.util.EnvironmentTestUtils;
+import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -70,11 +70,13 @@ public class ZipkinIntegrationTest {
 
     @Override
     public void initialize(ConfigurableApplicationContext configurableApplicationContext) {
-      EnvironmentTestUtils
-          .addEnvironment("zipkinrule", configurableApplicationContext.getEnvironment(),
-              String.format("opentracing.zipkin.http-sender.baseUrl=%s", zipkin.httpUrl()),
-              String.format("spring.application.name=%s", SERVICE_NAME)
-      );
+      TestPropertyValues.of(String.format("opentracing.zipkin.http-sender.baseUrl=%s", zipkin.httpUrl()))
+          .and(String.format("spring.application.name=%s", SERVICE_NAME))
+          .applyTo(
+                  configurableApplicationContext.getEnvironment(),
+                  TestPropertyValues.Type.MAP,
+                  "zipkinrule"
+        );
     }
   }
 

--- a/opentracing-spring-zipkin-web-starter/pom.xml
+++ b/opentracing-spring-zipkin-web-starter/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2018 The OpenTracing Authors
+    Copyright 2018-2019 The OpenTracing Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -27,7 +27,7 @@
 
     <properties>
         <main.basedir>${project.basedir}/..</main.basedir>
-        <opentracing-spring-web-starter.version>0.3.3</opentracing-spring-web-starter.version>
+        <opentracing-spring-web-starter.version>2.1.1</opentracing-spring-web-starter.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
 
     <version.io.opentracing>0.33.0</version.io.opentracing>
     <version.io.opentracing.contrib-opentracing-spring-tracer>0.2.0</version.io.opentracing.contrib-opentracing-spring-tracer>
-    <version.org.springframework.boot>1.5.12.RELEASE</version.org.springframework.boot>
+    <version.org.springframework.boot>2.1.7.RELEASE</version.org.springframework.boot>
     <version.brave-opentracing>0.34.2</version.brave-opentracing>
     <version.zipkin-sender-okhttp>2.10.1</version.zipkin-sender-okhttp>
     <version.zipkin>2.15.0</version.zipkin>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2018 The OpenTracing Authors
+    Copyright 2018-2019 The OpenTracing Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -63,27 +63,27 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <main.basedir>${project.basedir}</main.basedir>
 
-    <version.io.opentracing>0.31.0</version.io.opentracing>
-    <version.io.opentracing.contrib-opentracing-spring-tracer>0.1.0</version.io.opentracing.contrib-opentracing-spring-tracer>
+    <version.io.opentracing>0.33.0</version.io.opentracing>
+    <version.io.opentracing.contrib-opentracing-spring-tracer>0.2.0</version.io.opentracing.contrib-opentracing-spring-tracer>
     <version.org.springframework.boot>1.5.12.RELEASE</version.org.springframework.boot>
-    <version.brave-opentracing>0.31.3</version.brave-opentracing>
-    <version.zipkin-sender-okhttp>2.6.0</version.zipkin-sender-okhttp>
-    <version.zipkin>2.10.4</version.zipkin>
+    <version.brave-opentracing>0.34.2</version.brave-opentracing>
+    <version.zipkin-sender-okhttp>2.10.1</version.zipkin-sender-okhttp>
+    <version.zipkin>2.15.0</version.zipkin>
     <version.org.awaitility-awaitility>3.0.0</version.org.awaitility-awaitility>
     <version.test-containers>1.7.3</version.test-containers>
 
     <!-- plugins -->
-    <version.maven-compiler-plugin>3.6.2</version.maven-compiler-plugin>
+    <version.maven-compiler-plugin>3.8.1</version.maven-compiler-plugin>
     <version.maven-deploy-plugin>2.8.2</version.maven-deploy-plugin>
     <version.maven-license-plugin>3.0</version.maven-license-plugin>
     <version.maven-release-plugin>2.5.3</version.maven-release-plugin>
-    <version.maven-source-plugin>3.0.1</version.maven-source-plugin>
-    <version.maven-surefire-plugin>2.20</version.maven-surefire-plugin>
-    <version.maven-javadoc-plugin>3.0.0</version.maven-javadoc-plugin>
-    <version.maven-checkstyle-plugin>2.17</version.maven-checkstyle-plugin>
+    <version.maven-source-plugin>3.1.0</version.maven-source-plugin>
+    <version.maven-surefire-plugin>2.22.2</version.maven-surefire-plugin>
+    <version.maven-javadoc-plugin>3.1.1</version.maven-javadoc-plugin>
+    <version.maven-checkstyle-plugin>3.1.0</version.maven-checkstyle-plugin>
     <version.checkstyle>8.3</version.checkstyle>
-    <version.io.takari-maven>0.3.4</version.io.takari-maven>
-    <version.io.zikin.centralsync-maven-plugin>0.1.0</version.io.zikin.centralsync-maven-plugin>
+    <version.io.takari-maven>0.7.6</version.io.takari-maven>
+    <version.io.zikin.centralsync-maven-plugin>0.1.1</version.io.zikin.centralsync-maven-plugin>
   </properties>
 
   <dependencyManagement>
@@ -119,11 +119,6 @@
         <groupId>io.opentracing</groupId>
         <artifactId>opentracing-util</artifactId>
         <version>${version.io.opentracing}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.zipkin.java</groupId>
-        <artifactId>zipkin</artifactId>
-        <version>${version.zipkin}</version>
       </dependency>
       <dependency>
         <groupId>io.zipkin.zipkin2</groupId>


### PR DESCRIPTION
Currently, `java-spring-zipkin` is *broken* with `io.opentracing:opentracing-api:0.33.0`.

This PR upgrade to `io.opentracing:opentracing-api:0.33.0`, `org.springframework.boot:spring-boot-dependencies:2.1.7.RELEASE`,etc.

---

Please merge this, and release a new version(maybe 0.3.0?)  to make this project work.